### PR TITLE
Added GitPitch to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 **Deckset** (website: [Deckset](http://www.decksetapp.com)) – A macOS desktop app that renders Markdown presentations in beautifully designed templates.
 
+**GitPitch** (website: [GitPitch](http://gitpitch.com/), github: [gitpitch :octocat:](https://github.com/gitpitch/gitpitch/)) – Markdown Presentations For Everyone on GitHub, GitLab, Bitbucket, GitBucket, Gitea, and Gogs. [Example](https://gitpitch.com/gitpitch/gitpitch/master)
+
 ### Markdown to Portable Document Format (PDF)
 
 - [markdown-pdf :octocat:](https://github.com/alanshaw/markdown-pdf), [(npm Package)](https://www.npmjs.com/package/markdown-pdf) -  converts Markdown files to PDFs


### PR DESCRIPTION
## Project URL
- https://gitpitch.com/
- https://github.com/gitpitch/gitpitch/

## Category
- Markdown to Presentation / Slideshow

## Description
Added the open source presentation service [gitpitch](https://github.com/gitpitch/gitpitch/) to the list of markdown tools.
 
## Why it should be included to `awesome-markdown`
You can use the very powerful [Reveal.js](https://revealjs.com/) framework without downloading or installing anything. You just need to add a PITCHME.md file in your repository. The basic service on gitpitch.com is absolutely free for everyone. Pro features add desktop tools, advanced image support, and access to private Git repos. Check out the cool write-up [here](https://medium.com/@gitpitch/use-git-to-deliver-stunning-slideshow-presentations-5dbdf644d4cc).

## Checklist
- [x] Only one project/change is in this pull request
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English