### PR TITLE
Add 'quikdown' markdown parser details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **mdcode**
 (github: [mdcode](https://github.com/szkiba/mdcode)) Markdown code block authoring tool. It enables testable code blocks, with two-way synchronization between code blocks and source files.
 
+**quikdown**
+  ([web](https://deftio.github.io/quikdown/), [npm](https://www.npmjs.com/package/quikdown), [github 
+  :octocat:](https://github.com/deftio/quikdown)) Lightweight (10KB) markdown parser with bidirectional
+  HTML conversion, built-in XSS protection, and extensible plugin system. Zero dependencies, works in browser and
+  Node.js. Features include drop-in editor component, TypeScript support, and lazy linefeeds for chat applications.
+  ([Live Parser Demo](https://deftio.github.io/quikdown/examples/quikdown-live.html), [Editor 
+  Demo](https://deftio.github.io/quikdown/examples/qde/))
+  
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax


### PR DESCRIPTION
Adding QuikDown, a lightweight  markdown parser with focus on security and small bundle size.  Subset of commonmark.  Actively maintained with 95%+ test coverage.  Also includes a drop in editor component.  Live demos on github.