### PR TITLE
feat(mk-notes): add Mk Notes entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,10 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 * **markedpp** (github: [markedpp :octocat:](https://github.com/commenthol/markedpp)) adds support for table-of-contents (TOC), numbered headings, includes other markdown files and/or create reference lists for use with different markdown processors like [marked](#marked), [markdown-it](#markdown-it), [pandoc](#pandoc) or for hosting on github.com, gitlab.com, bitbucket.org or ghost.org.
 
+### Markdown to Notion
+
+* [mk-notes](https://github.com/Myastr0/mk-notes) - Sync your local Markdown files seamlessly to Notion. Keep writing in Markdown and let mk-notes handle the integration.
+
 
 ## Convert to Markdown Tools
 


### PR DESCRIPTION
# Description

This PR adds [mk-notes](https://github.com/Myastr0/mk-notes) to the new **Markdown to Notion** section of the list.

mk-notes is an open-source CLI that allows users to seamlessly sync their local Markdown files with Notion. It helps developers and teams keep writing in Markdown while automatically handling the integration with Notion.

As the maintainer of mk-notes ([Myastr0 on GitHub](https://github.com/Myastr0)), I believe it’s a relevant addition to the collection of Markdown-related tools, especially for users who want to bridge Markdown workflows with Notion.