### PR TITLE
Add file2markdown.ai to PDF/Office to Markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 - [doc2md :octocat:](https://github.com/orangefineblue/doc2md) - high-fidelity PDF, DOCX, and PPTX to Markdown conversion pipeline with multi-extractor support (pymupdf, pdfplumber, MinerU), image extraction, per-image classification, and multi-stage quality control
 
+- [file2markdown.ai](https://file2markdown.ai) - AI-powered converter that turns PDFs, Word docs, and images into clean structured Markdown. Optimized for RAG pipelines and Obsidian. Free tier available (20 conversions/day).
+
 ### WordStar to Markdown
 - [ws2markdown](https://code.rosaelefanten.org/ws2markdown) - convert WordStar (.ws) into Markdown (.md) files
 


### PR DESCRIPTION
Hi, I'd like to suggest adding file2markdown.ai to the Productivity Tools section. It's an AI-powered file conversion tool that turns PDFs, Word docs, and images into clean structured Markdown — useful for RAG pipelines, knowledge bases, and tools like Obsidian. Free tier available (20 conversions/day, no signup required).