### PR TITLE
Add Patitas

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ markdown library & command line tool (in Ruby)
 (web: [`markdown-it.github.io`](https://markdown-it.github.io/), github: [markdown-it :octocat:](https://github.com/markdown-it/markdown-it)) Javascript markdown parser. 100% CommonMark support, extensions, syntax plugins & high speed.
 Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it-plugin).
 
+<a name="patitas"></a>
+
+**Patitas**
+(github: [patitas :octocat:](https://github.com/lbliii/patitas), pypi: [`patitas`](https://pypi.org/project/patitas/)) typed Markdown parser for Python. CommonMark 0.31.2 compliant, renders to HTML, and supports frontmatter, directives, and incremental parsing.
+
 **concat-md**
 ([npm](https://www.npmjs.com/package/concat-md), [github](https://github.com/ozum/concat-md#readme)) CLI and API to concatenate markdown files and modify as necessary. Also adds titles from FrontMatter, file names and directory names, decreases level of existing titles to comply with added titles.
 


### PR DESCRIPTION
## Summary
- add `Patitas` to the Markdown Libraries & Tools section
- describe it as a Python Markdown parser with CommonMark support
- keep the change scoped to a single README entry

## Test plan
- [x] reviewed README-only diff
- [x] matched the surrounding README formatting
- [ ] no local CI run; documentation-only change

Made with [Cursor](https://cursor.com)