### PR TITLE
Add Markdown Utils — free browser-based markdown toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 ### Markdown to Portable Document Format (PDF)
 
+
+- [Markdown Utils](https://markdownutils.com/) - Free browser-based markdown toolkit — live editor with preview, markdown to PDF converter with
+   themes & fonts, diff & compare, formatter, and table generator. Runs entirely client-side, no sign-up. ![Globe][globe]
 - [markdown-pdf :octocat:](https://github.com/alanshaw/markdown-pdf), [(npm Package)](https://www.npmjs.com/package/markdown-pdf) -  converts Markdown files to PDFs
 - [em-dee-pdf :octocat:](https://github.com/brendandebeasi/em-dee-pdf) - converts Markdown files to styled PDFs using Typst with 18 built-in themes, LaTeX math, and syntax highlighting
 - [Resumx](https://resumx.dev) [:octocat:](https://github.com/resumx/resumx) - Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG


### PR DESCRIPTION
Markdown Utils is a free, client-side markdown toolkit at https://markdownutils.com with:                                                    
                                                                                                                                                 
  - Live editor with preview
  - Markdown to PDF converter (5 themes, 13 fonts, margin controls)                                                                              
  - Diff & compare                                                                                                                             
  - Formatter                                                                                                                                    
  - Table generator                                                                                                                              
                   
  No sign-up, no upload — everything runs in the browser. 