### PR TITLE
Add SnapAPI to Markdown Libraries & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **mq**
 (web: [mqlang.org](https://mqlang.org), github: [mq :octocat:](https://github.com/harehare/mq)) A command-line tool that processes Markdown using a syntax similar to jq. Written in Rust, allowing you to easily slice, filter, map, and transform structured data in Markdown files.
 
+**SnapAPI**
+(web: [`api-snap.com`](https://api-snap.com)) - REST API that converts Markdown to HTML (among 13+ other utility endpoints including QR codes, screenshots, HTML-to-PDF, and more)
+
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 


### PR DESCRIPTION
Add [SnapAPI](https://api-snap.com) to the Markdown Libraries & Tools section.

SnapAPI is a REST API service that includes a Markdown-to-HTML conversion endpoint, alongside 13+ other utility APIs (QR codes, screenshots, image resize, URL metadata, HTML-to-PDF, and more).

It fits naturally among the existing markdown processing tools and libraries listed in this section, as an API-based approach to markdown conversion.