### PR TITLE
Add MacMD Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
 **MacMD Viewer**
-(web: [`macmdviewer.com`](https://macmdviewer.com)) -
+(web: [`macmdviewer.com`](https://macmdviewer.com), github: [MacMD Viewer :octocat:](https://github.com/macmdviewer/MacMDViewer)) -
 native macOS Markdown viewer with Mermaid diagram rendering, syntax highlighting for 190+ languages, and a QuickLook extension for Finder preview
 
 ### Babelmark


### PR DESCRIPTION
Adding MacMD Viewer, a native macOS Markdown viewer. Renders GitHub Flavored Markdown with Mermaid diagram support, syntax highlighting for 190+ languages, and includes a QuickLook extension for Finder preview.