### PR TITLE
Add md-preview to Markdown Libraries & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
+**md-preview**
+(github: [md-preview :octocat:](https://github.com/vorojar/md-preview)) Ultra-lightweight Markdown preview app (~1MB binary) built with Rust, with offline syntax highlighting, dark mode, and cross-platform support.
+
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax


### PR DESCRIPTION
## Summary

- Add [md-preview](https://github.com/vorojar/md-preview) to the **Markdown Libraries & Tools** section.
- md-preview is an ultra-lightweight Markdown preview app (~1MB binary) built with Rust, with offline syntax highlighting, dark mode, and cross-platform support.

Thank you for maintaining this awesome list!