### PR TITLE
Add Save to Commercial Edition (HTML to Markdown)

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,3 +1,9 @@
 
 # Awesome Markdown - The Commercial Edition
 
+
+## Convert to Markdown Tools
+
+### Hypertext Markup Language (HTML) to Markdown
+
+- [Save](https://www.savemarkdown.co), [(Chrome Web Store)](https://chromewebstore.google.com/detail/save-%E2%80%94-web-to-markdown/mamnlljnkigkhppbjhmpdeocobcbobdp) - one-click Chrome extension that turns any webpage into clean Markdown using AI (Gemini). Handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard pages. Optional macOS and Windows companion app (Save Vault) stores saves locally and exposes them to Claude via MCP.


### PR DESCRIPTION
Follow-up to #84 — per @geraldb's suggestion, adding Save to the new `COMMERCIAL.md` page instead of the main README.

Save is a Chrome extension that turns any webpage into clean Markdown with one click, powered by Gemini. It handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard articles. An optional macOS and Windows companion app (Save Vault) stores saves locally and makes them queryable by Claude via MCP.

- Website: https://www.savemarkdown.co
- Chrome Web Store: https://chromewebstore.google.com/detail/save-%E2%80%94-web-to-markdown/mamnlljnkigkhppbjhmpdeocobcbobdp

Also seeded the file with a `## Convert to Markdown Tools` → `### HTML to Markdown` section so future entries have a place to land — happy to restructure if you'd prefer a different layout.