### PR TITLE
Add Dualmark to Markdown Libraries & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,6 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
-**Dualmark**
-(web: [`dualmark.dev`](https://dualmark.dev), github: [dodopayments/dualmark :octocat:](https://github.com/dodopayments/dualmark), [npm](https://www.npmjs.com/package/@dualmark/core)) Markdown-first web infrastructure. Auto-generates a markdown twin of every page (e.g. `/pricing` + `/pricing.md`) and serves it via HTTP content negotiation when AI crawlers visit — same URL, two formats. TypeScript, Apache 2.0, adapters for Astro, Next.js, and Cloudflare Workers.
-
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax

--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
+**Dualmark**
+(web: [`dualmark.dev`](https://dualmark.dev), github: [dodopayments/dualmark :octocat:](https://github.com/dodopayments/dualmark), [npm](https://www.npmjs.com/package/@dualmark/core)) Markdown-first web infrastructure. Auto-generates a markdown twin of every page (e.g. `/pricing` + `/pricing.md`) and serves it via HTTP content negotiation when AI crawlers visit — same URL, two formats. TypeScript, Apache 2.0, adapters for Astro, Next.js, and Cloudflare Workers.
+
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -18,6 +18,8 @@
 
 **LiteMarkup**  (GitHub: [tuures/LiteMarkup](https://github.com/tuures/LiteMarkup), NPM: [litemarkup](https://www.npmjs.com/package/litemarkup), Web: [Live demo](https://tuures.github.io/LiteMarkup/docs/demopage.html)) Parser with a typed, AST-first TypeScript API. Under 3 KB gzipped, zero dependencies. LiteMarkup supports the most popular Markdown features while maintaining a small bundle size, good performance, and strong AST extensibility. A simple HTML string renderer is included for demonstration and simple use cases, but users are expected to bring their own renderer tailored to their specific use case and context, such as rendering to React, docx, or something else. LiteMarkup performance is roughly on par with popular JS-based implementations like commonmark, marked, and markdown-it, but naturally slower than WASM-based ones.
 
+**Dualmark**  (web: [dualmark.dev](https://dualmark.dev), github: [dodopayments/dualmark](https://github.com/dodopayments/dualmark), npm: [@dualmark/core](https://www.npmjs.com/package/@dualmark/core)) Markdown-first web infrastructure. Auto-generates a markdown twin of every page (e.g. `/pricing` + `/pricing.md`) and serves it via HTTP content negotiation when AI crawlers visit — same URL, two formats. TypeScript, Apache 2.0, adapters for Astro, Next.js, and Cloudflare Workers.
+
 
 ### Babelmark
 


### PR DESCRIPTION
Adds [Dualmark](https://github.com/dodopayments/dualmark) under **Markdown Building Blocks → Markdown Libraries & Tools**, alongside markdown-to-jsx.

**What it is:** Markdown-first web infrastructure. Auto-generates a markdown twin of every page (e.g. `/pricing` + `/pricing.md`) and serves it via HTTP content negotiation when an AI crawler UA is detected — same URL, two formats. TypeScript, Apache 2.0, adapters for Astro / Next.js / Cloudflare Workers.

- Repo: https://github.com/dodopayments/dualmark
- Live: https://dualmark.dev (the site dogfoods what it implements — try `curl -H "Accept: text/markdown" https://dualmark.dev/`)
- npm: `@dualmark/core` (+ 5 sibling packages), provenance attested

Followed the existing multi-line `**Name**` entry format. Happy to adjust if I should use a different style.