### PR TITLE
Add MDMagic to UPCOMING.md

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -44,6 +44,8 @@
 
 ### Markdown to Portable Document Format (PDF)
 
+**MDMagic** (web: https://mdmagic.ai, github: https://github.com/MDMagic-MCP/mdmagic-mcp-server) - convert Markdown to Word, PDF, and HTML using your own Word templates - letterhead, fonts, branding applied automatically. Web app + MCP server for Claude, Cursor, OpenClaw, and any MCP-compatible AI assistant. Freemium.
+
 
 ### Markdown Styles / Documents / Pages
 


### PR DESCRIPTION
Following the 2026 listing policy — adding MDMagic to UPCOMING.md first.

MDMagic converts Markdown to Word, PDF, and HTML using your own Word templates. Custom letterhead, fonts, footers, and brand colours apply automatically. Available as a web app at https://mdmagic.ai and as an MCP server (`@mdmagic/mcp-server` on npm) for Claude Desktop, Claude Code, Cursor, OpenClaw, and any MCP-compatible AI assistant.

Source code (MCP server, MIT licensed): https://github.com/MDMagic-MCP/mdmagic-mcp-server

Placed under `### Markdown to Portable Document Format (PDF)` since the existing precedent in the main README is Resumx (Markdown → PDF/HTML/DOCX/PNG) which sits in that section despite producing more than just PDF.

Thanks for maintaining this list.