### PR TITLE
Add linkedin2md: zero-dependency LinkedIn data export → Markdown CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 - [Jimmy :octocat:](https://github.com/marph91/jimmy) - Convert your notes to Markdown
 
+### LinkedIn / Career Data to Markdown
+
+- [linkedin2md :octocat:](https://github.com/juanmanueldaza/linkedin2md), [:snake:](https://pypi.org/project/linkedin2md/) - zero-dependency Python CLI to convert LinkedIn data export ZIPs into clean, structured Markdown files optimized for LLM analysis; optional PDF resume generation via `--pdf`
+
 ### Hypertext Markup Language (HTML) to Markdown
 
 Ruby


### PR DESCRIPTION
## linkedin2md

Adds a new subsection "LinkedIn / Career Data to Markdown" under "Convert to Markdown Tools".

**Project:** https://github.com/juanmanueldaza/linkedin2md  
**PyPI:** https://pypi.org/project/linkedin2md/

### What it does

linkedin2md is a zero-dependency Python CLI that converts LinkedIn data export ZIPs into clean, structured Markdown files. It parses 40+ LinkedIn sections (experience, skills, recommendations, job applications, connections, etc.) and produces `.md` files ready for any Markdown tool or LLM context window.

### Why it belongs here

- Fits squarely in the **"Convert to Markdown Tools"** category alongside Word→MD, PDF→MD, HTML→MD tools
- 4,500+ PyPI downloads, actively maintained (v0.3.1, May 2026)
- Open source (GPL-2.0), zero core dependencies
- Optional `--pdf` flag generates A4 print-ready PDF resumes from parsed data
- Bilingual output (English/Spanish)

### Format

Follows the existing awesome-markdown entry style (octocat + snake badges, one-line description).

---
*Added in alphabetical order within a new subsection.*