### PR TITLE
Add FolioMD - Free online PDF to Markdown converter

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -71,6 +71,7 @@
 
 ### PDF / Office Documents to Markdown
 
+- [FolioMD](https://foliomd.es) - Free online PDF to Markdown converter with OCR, table extraction, and image support.
 
 ### WordStar to Markdown
 


### PR DESCRIPTION
## Add FolioMD to Awesome Markdown

This PR adds [FolioMD](https://foliomd.es) to the **PDF / Office Documents to Markdown** section in `UPCOMING.md`.

### About FolioMD

FolioMD is a **free online PDF to Markdown converter** that supports:

- **OCR** — Extract text from scanned PDFs and images
- **Table extraction** — Convert PDF tables to proper Markdown tables
- **Image support** — Preserve images from the original document

The tool is completely free to use and runs entirely in the browser, making it easy for anyone to convert PDFs to clean Markdown without installing any software.

### Changes

- Added FolioMD entry to the `UPCOMING.md` file under the "PDF / Office Documents to Markdown" section, following the 2026 policy of adding new listings to the Upcoming page first.