### PR TITLE
Add ai-slop-detect to Markdown Lint section

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ to be done
 
 ### Markdown Lint / Style Rule Checker
 
+- [ai-slop-detect](https://github.com/antydizajn/ai-slop-detect) - Free Python CLI that flags AI-generated text patterns in markdown and prose (em-dashes, ChatGPT phrases like "leverage" / "cutting-edge", punctuation density, zero-width unicode tells). EN+PL, MIT, GitHub Action included.
 - [markdownlint](https://github.com/DavidAnson/markdownlint) - A Node.js style checker and lint tool for Markdown/CommonMark files offering a good set of defaults. Allows for customization.
 - [mdformat](https://github.com/executablebooks/mdformat) - CommonMark compliant Markdown formatter
 - [mdlint]() to be done


### PR DESCRIPTION
[ai-slop-detect](https://github.com/antydizajn/ai-slop-detect) is a free, MIT-licensed Python CLI that flags AI-generated text patterns specifically in markdown and prose: em-dashes, ChatGPT phrases ("leverage", "cutting-edge", "unleash", "gamechanger"), punctuation density, and zero-width unicode tells.

Different scope from markdownlint (style/syntax) - this checks for LLM-generated text quality. Pairs well with markdownlint in CI.

EN + PL, GitHub Action included.