### PR TITLE
Add slopless

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -31,7 +31,7 @@
 
 ### Markdown Lint / Style Rule Checker
 
-**slopless**  (github: [seochecks-ai/slopless](https://github.com/seochecks-ai/slopless), npm: [slopless](https://www.npmjs.com/package/slopless)) Deterministic textlint preset and CLI that flags AI-generated and padded English prose without calling an LLM. It catches the common "LLM tells" — hollow framing, fake "not X but Y" contrasts, hedging, em-dash overuse, vacuous closers — and emits reproducible JSON findings, so it runs in CI. Use it via `npx slopless` or as a textlint preset (`"preset-slopless": true`). MIT-licensed.
+**slopless**  (github: [seochecks-ai/slopless](https://github.com/seochecks-ai/slopless), npm: [slopless](https://www.npmjs.com/package/slopless)) Deterministic textlint preset and CLI to flag AI-generated and padded English prose without calling an LLM. It catches the common "LLM tells" — hollow framing, fake "not X but Y" contrasts, hedging, em-dash overuse, vacuous closers — and emits reproducible JSON findings, so it runs in CI. Use it via `npx slopless` or as a textlint preset (`"preset-slopless": true`). MIT-licensed.
 
 ### Markdown Web Components / Custom Elements
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -31,6 +31,8 @@
 
 ### Markdown Lint / Style Rule Checker
 
+**slopless**  (github: [seochecks-ai/slopless](https://github.com/seochecks-ai/slopless), npm: [slopless](https://www.npmjs.com/package/slopless)) Deterministic textlint preset and CLI that flags AI-generated and padded English prose without calling an LLM. It catches the common "LLM tells" — hollow framing, fake "not X but Y" contrasts, hedging, em-dash overuse, vacuous closers — and emits reproducible JSON findings, so it runs in CI. Use it via `npx slopless` or as a textlint preset (`"preset-slopless": true`). MIT-licensed.
+
 ### Markdown Web Components / Custom Elements
 
 


### PR DESCRIPTION
Adds **slopless** to the *Markdown Lint / Style Rule Checker* section of UPCOMING.md (per the 2026 policy of staging new entries there first).

slopless is a deterministic textlint preset and zero-config CLI that flags AI-generated and padded English-Markdown prose without calling an LLM, emitting reproducible JSON findings suitable for CI. It fits this list as a Markdown lint / style rule checker.

- GitHub: https://github.com/seochecks-ai/slopless
- npm: https://www.npmjs.com/package/slopless