### PR TITLE
Add pdfmarkdown.app to PDF / Office Documents to Markdown

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -8,6 +8,11 @@
 
 - [Save](https://www.savemarkdown.co), [(Chrome Web Store)](https://chromewebstore.google.com/detail/save-%E2%80%94-web-to-markdown/mamnlljnkigkhppbjhmpdeocobcbobdp) - one-click Chrome extension that turns any webpage into clean Markdown using AI (Gemini). Handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard pages. Optional macOS and Windows companion app (Save Vault) stores saves locally and exposes them to Claude via MCP.
    
+### PDF to Markdown
+
+- [pdfmarkdown.app](https://pdfmarkdown.app) - free, in-browser PDF to Markdown converter; keeps tables, formulas and images, with side-by-side output you can check. No upload, no signup. Also Markdown to PDF.
+
 ## Markdown to Portable Document Format (PDF)
 
 - [MarkDone](https://markdone.dev/markdown-to-pdf/) - convert Markdown to PDF locally in your browser with live preview, tables, code blocks, and Mermaid diagrams. No upload, no account needed. Freemium.
+- [pdfmarkdown.app](https://pdfmarkdown.app/markdown-to-pdf) - convert Markdown to PDF in your browser with a side-by-side live preview and themes; tables, code blocks, math (LaTeX) and images all render, and you can import a .zip of Markdown files and images. No upload, no signup. Free. Also PDF to Markdown.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -74,7 +74,6 @@
 ### PDF / Office Documents to Markdown
 
 - [FolioMD](https://foliomd.es) - Free online PDF to Markdown converter with OCR, table extraction, and image support.
-- [pdfmarkdown.app](https://pdfmarkdown.app) - Free, in-browser PDF to Markdown converter; keeps tables, formulas and images, with side-by-side output you can check. No upload, no signup. Also Markdown to PDF.
 
 ### WordStar to Markdown
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -74,6 +74,7 @@
 ### PDF / Office Documents to Markdown
 
 - [FolioMD](https://foliomd.es) - Free online PDF to Markdown converter with OCR, table extraction, and image support.
+- [pdfmarkdown.app](https://pdfmarkdown.app) - Free, in-browser PDF to Markdown converter; keeps tables, formulas and images, with side-by-side output you can check. No upload, no signup. Also Markdown to PDF.
 
 ### WordStar to Markdown
 


### PR DESCRIPTION
Adds **pdfmarkdown.app** under *Convert to Markdown Tools → PDF / Office Documents to Markdown* in `UPCOMING.md` (per the 2026 policy of adding new entries to UPCOMING first).

pdfmarkdown.app is a free, in-browser PDF to Markdown converter that keeps tables, formulas and images intact and shows the result side by side with the original so you can check it. No upload, no signup. It also does Markdown to PDF.

Single entry, matched to the existing format in that section.
