### PR TITLE
Add MD Converter - AI-powered Markdown conversion extensionAdd MD Converter link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ a free web alternative to PowerPoint and Keynote in Ruby
 - [doc2md :octocat:](https://github.com/orangefineblue/doc2md) - high-fidelity PDF, DOCX, and PPTX to Markdown conversion pipeline with multi-extractor support (pymupdf, pdfplumber, MinerU), image extraction, per-image classification, and multi-stage quality control
 
 - [file2markdown.ai](https://file2markdown.ai) - AI-powered converter that turns PDFs, Word docs, and images into clean structured Markdown. Optimized for RAG pipelines and Obsidian. Free tier available (20 conversions/day).
+- [MD Converter :octocat:](https://github.com/DRAMV/md-converter-extension) - AI-powered Chrome extension that converts webpages, PDFs, images, and Office files to Markdown using Google Gemini.
 
 ### WordStar to Markdown
 - [ws2markdown](https://code.rosaelefanten.org/ws2markdown) - convert WordStar (.ws) into Markdown (.md) files


### PR DESCRIPTION
Hi! I'd like to add MD Converter, an open-source Chrome extension that uses Google Gemini to convert webpages, PDFs, images, and Office files to Markdown.

I added the entry alphabetically to the "PDF / Office Documents to Markdown" section and included the :octocat: emoji since the source code is on GitHub. 

I also noticed your new policy regarding 2026 listings. I've added this directly to the README for now, but please let me know if you'd prefer I move this entry to the UPCOMING.md file instead. Happy to adjust!