### PR TITLE
Add md0 - free online Markdown converters (HTML to Markdown, Markdown to PDF)

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -25,3 +25,9 @@
 ## Mermaid Diagrams to Portable Document Format (PDF)
 
 - [Mermaid Online](https://mermaidonline.org) - free browser-based Mermaid diagram converter for previewing diagrams and exporting PNG, SVG, JPG, WebP, and PDF assets. No signup or watermark.
+
+## Markdown to Website / Blog
+
+**md0 CMS**
+(web: [`cms.md0.io`](https://cms.md0.io)) - GitHub-backed headless CMS for Markdown content. Connect any GitHub repository, define content collections with a schema builder, and edit Markdown files through a visual WYSIWYG editor — changes commit directly to your repo. Built for static site generators (Next.js, Astro, Hugo, etc.). Free to use.
+

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,4 +1,3 @@
-
 # Awesome Markdown - The Commercial Edition
 
 
@@ -7,6 +6,7 @@
 ### Hypertext Markup Language (HTML) to Markdown
 
 - [Save](https://www.savemarkdown.co), [(Chrome Web Store)](https://chromewebstore.google.com/detail/save-%E2%80%94-web-to-markdown/mamnlljnkigkhppbjhmpdeocobcbobdp) - one-click Chrome extension that turns any webpage into clean Markdown using AI (Gemini). Handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard pages. Optional macOS and Windows companion app (Save Vault) stores saves locally and exposes them to Claude via MCP.
+- [md0 HTML to Markdown](https://md0.io/html-to-markdown) - free online HTML to Markdown converter with live preview. Paste HTML or a snippet and get clean Markdown instantly. No account needed.
    
 ### PDF to Markdown
 
@@ -20,6 +20,7 @@
 
 - [MarkDone](https://markdone.dev/markdown-to-pdf/) - convert Markdown to PDF locally in your browser with live preview, tables, code blocks, and Mermaid diagrams. No upload, no account needed. Freemium.
 - [pdfmarkdown.app](https://pdfmarkdown.app/markdown-to-pdf) - convert Markdown to PDF in your browser with a side-by-side live preview and themes; tables, code blocks, math (LaTeX) and images all render, and you can import a .zip of Markdown files and images. No upload, no signup. Free. Also PDF to Markdown.
+- [md0 Markdown to PDF](https://md0.io/to-pdf) - free browser-based Markdown to PDF converter with live preview. No upload, no account needed.
 
 ## Mermaid Diagrams to Portable Document Format (PDF)
 


### PR DESCRIPTION
## What is md0?

**md0** (md0.io) is a free suite of online Markdown tools with no login required.

Since there is no public source code, I've added it to COMMERCIAL.md per the 2026 contribution policy.

### Added: Convert to Markdown > HTML to Markdown

- [md0 HTML to Markdown](https://md0.io/html-to-markdown) — free online converter with live preview, no account needed.

### Added: Markdown to PDF

- [md0 Markdown to PDF](https://md0.io/to-pdf) — free browser-based converter with live preview, no account needed.

### Added: Markdown to Website / Blog

**md0 CMS** (cms.md0.io) — GitHub-backed headless CMS for Markdown content. Connect any GitHub repository, define content collections with a schema builder, and edit Markdown files through a visual WYSIWYG editor — changes commit directly to your repo. Built for static site generators (Next.js, Astro, Hugo, etc.).