### PR TITLE
Add markupmarkdown to Markdown Libraries & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
+**markupmarkdown**
+(web: [`mumd.metavert.io`](https://mumd.metavert.io),
+ github: [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) - "Google Docs for Markdown" — collaborative review & editing for `.md` files: anchored comment threads, suggested changes, review states, document checks, and GitHub round-trip (open any repo's Markdown, push edits back as a PR). Includes an MCP server so AI agents can review documents alongside humans. Open source (MIT, in Go + React).
+
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax

--- a/README.md
+++ b/README.md
@@ -316,10 +316,6 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
-**markupmarkdown**
-(web: [`mumd.metavert.io`](https://mumd.metavert.io),
- github: [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) - "Google Docs for Markdown" — collaborative review & editing for `.md` files: anchored comment threads, suggested changes, review states, document checks, and GitHub round-trip (open any repo's Markdown, push edits back as a PR). Includes an MCP server so AI agents can review documents alongside humans. Open source (MIT, in Go + React).
-
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,6 +9,9 @@
 
 ### Markdown Libraries & Tools
 
+**markupmarkdown**  (web: [mumd.metavert.io](https://mumd.metavert.io), github: [jonradoff/markupmarkdown](https://github.com/jonradoff/markupmarkdown)) "Google Docs for Markdown" — collaborative review & editing for `.md` files: anchored comment threads, suggested changes with one-click apply, review states, document checks, and GitHub round-trip (open any repo's Markdown, push edits back as a PR). Includes an MCP server so AI agents can review documents alongside humans. MIT licensed, built with Go + React.
+
+
 
 **mdshare**  (web: [mdshare.live](https://mdshare.live), github: [urbanmorph/mdshare](https://github.com/urbanmorph/mdshare), npm: [mdshare-mcp](https://www.npmjs.com/package/mdshare-mcp)) Free markdown sharing and collaboration. Upload a markdown, get shareable links with view/edit/comment permissions. WYSIWYG editor, inline comments, no login required. API + MCP server for AI integration.
 


### PR DESCRIPTION
Adds [markupmarkdown](https://github.com/jonradoff/markupmarkdown) — an open-source (MIT, Go + React) "Google Docs for Markdown": collaborative review and editing for `.md` files.

Highlights:
- Anchored comment threads with suggested changes and one-click apply
- Review states (approve / request changes) that gate pushing edits
- GitHub round-trip: open any repo's Markdown file, edit, push back as a PR
- Document checks (definable lint-style policies)
- Built-in MCP server so AI agents can review documents alongside humans

Live at https://mumd.metavert.io — entry follows the existing format in the Markdown Libraries & Tools section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)