### PR TITLE
Add MDMA (interactive Markdown / mounted applications)

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -26,6 +26,8 @@
 
 **Embridge** (web: [embridge.net](https://embridge.net), github: [embridge-foundation/embridge](https://github.com/embridge-foundation/embridge), npm: [embridge](https://www.npmjs.com/package/embridge)) Markdown-based item and task list format that aims to be flexible and human-friendly while providing enough structure for automated parsers and AI agents. With stable IDs, metadata fields, comments, attachments, and a reference validator. Suitable for Kanban boards and calendars too.
 
+**MDMA** (web: [mdma.software](https://mdma.software), github: [MobileReality/mdma](https://github.com/MobileReality/mdma), npm: [@mobile-reality/mdma-renderer-react](https://www.npmjs.com/package/@mobile-reality/mdma-renderer-react)) Markdown Document with Mounted Applications — extends Markdown with interactive components (forms, tables, approval gates, charts, callouts, webhooks) declared in fenced ` ```mdma ` blocks, so an LLM responds with validated, renderable UI instead of plain text. Parser is a remark plugin; ships a React renderer, a validator, a prompt-pack, a CLI, and an MCP server. Open source, MIT. Built by [Mobile Reality](https://themobilereality.com).
+
 
 ### Babelmark
 


### PR DESCRIPTION
Adds **MDMA** (Markdown Document with Mounted Applications) under *Markdown Building Blocks → Markdown Libraries & Tools* in UPCOMING.md.

MDMA extends Markdown with interactive components (forms, tables, approval gates, charts, callouts, webhooks) declared in fenced ```mdma``` blocks, so an LLM can respond with validated, renderable UI instead of plain text. The parser is a remark plugin; the project also ships a React renderer, validator, prompt-pack, CLI, and an MCP server.

- Web: https://mdma.software
- Source: https://github.com/MobileReality/mdma
- npm: https://www.npmjs.com/package/@mobile-reality/mdma-renderer-react
- License: MIT

Entry follows the existing format in the section (web / github / npm links + description).