### PR TITLE
Add Tinta - fast, lightweight markdown viewer for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ Is extensible with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it
 **markdown-to-jsx**
 (web: [markdown-to-jsx.quantizor.dev](https://markdown-to-jsx.quantizor.dev), github: [markdown-to-jsx :octocat:](https://github.com/quantizor/markdown-to-jsx), [npm](https://www.npmjs.com/package/markdown-to-jsx)) A very fast and versatile markdown toolchain. Output to AST, React, React Native, SolidJS, Vue, HTML, and more!
 
+**Tinta**
+(web: [`tinta.cc`](https://tinta.cc), github: [Tinta :octocat:](https://github.com/oipoistar/tinta)) A fast, lightweight markdown viewer for Windows. Native C++ with Direct2D/DirectWrite rendering - single portable exe under 1 MB, ~200 ms startup, 10 themes, table of contents, search, and edit mode with live preview.
+
 ### Babelmark
 
 - [Babelmark 2]() - a tool for comparing the output of various implementations of Markdown syntax


### PR DESCRIPTION
Adds **Tinta** to Markdown Libraries & Tools, following the existing entry format.

Tinta is a fast, lightweight markdown viewer for Windows — native C++ with Direct2D/DirectWrite rendering, single portable exe under 1 MB, ~200 ms startup, MIT licensed. 10 themes, table of contents, search, edit mode with live preview.

- Web: https://tinta.cc
- GitHub: https://github.com/oipoistar/tinta
- I'm the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)