### PR TITLE
Update Save entry: renamed to Minibase

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -6,7 +6,7 @@
 
 ### Hypertext Markup Language (HTML) to Markdown
 
-- [Save](https://www.savemarkdown.co), [(Chrome Web Store)](https://chromewebstore.google.com/detail/save-%E2%80%94-web-to-markdown/mamnlljnkigkhppbjhmpdeocobcbobdp) - one-click Chrome extension that turns any webpage into clean Markdown using AI (Gemini). Handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard pages. Optional macOS and Windows companion app (Save Vault) stores saves locally and exposes them to Claude via MCP.
+- [Minibase](https://www.minibase.md), [(Chrome Web Store)](https://chromewebstore.google.com/detail/mamnlljnkigkhppbjhmpdeocobcbobdp) - one-click browser extension (Chrome and Firefox) that turns any webpage into clean Markdown using AI. Handles X/Twitter threads, YouTube transcripts, Instagram reels, TikToks, and standard pages. Optional macOS and Windows companion app (Minibase Vault) stores saves locally and exposes them to Claude via MCP. (formerly Save)
    
 ### PDF to Markdown
 


### PR DESCRIPTION
Updates the "Save" entry to reflect its rename to "Minibase" (new URL www.minibase.md) and the fact that it now ships on Firefox as well as Chrome. The companion app is now "Minibase Vault". Old links still redirect; this keeps the listing accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)