### PR TITLE
Add Markdown Cheat Sheet & Flavor Compatibility Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Character encoding
 
 - [Markdown Cheatsheet :octocat:](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 - [The Ultimate Markdown Cheat Sheet](https://github.com/lifeparticle/Markdown-Cheatsheet)
+- [Markdown Cheat Sheet & Flavor Compatibility Matrix](https://www.markdowntools.io/cheat-sheet) - Cross-platform cheat sheet with GitHub / Obsidian / Jupyter / Discord / Slack support states per feature, plus printable PDFs.
 
 ### Markdown Getting Started Guides / Tutorials
 


### PR DESCRIPTION
Adds [Markdown Cheat Sheet & Flavor Compatibility Matrix](https://www.markdowntools.io/cheat-sheet) under Markdown Cheatsheets / Quick References.

The distinctive part is the flavor compatibility matrix: per-feature support states across GitHub, Obsidian, Jupyter, Discord, and Slack. Printable PDF versions (generic, GitHub, Obsidian, Jupyter) are linked from the same page. Should sit nicely next to the existing quick references for anyone debugging cross-platform rendering differences.
