### PR TITLE
Add Markstream streaming Markdown renderer

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,6 +9,7 @@
 
 ### Markdown Libraries & Tools
 
+**Markstream** (web: [markstream.simonhe.me](https://markstream.simonhe.me/), github: [Simon-He95/markstream-vue](https://github.com/Simon-He95/markstream-vue), npm: [markstream-vue](https://www.npmjs.com/package/markstream-vue)) - Open-source streaming Markdown renderer for Vue, React, Svelte, and Angular AI chat interfaces. Handles incomplete Markdown while tokens arrive and supports Mermaid, KaTeX, long responses, and streaming code blocks.
 
 **mdshare**  (web: [mdshare.live](https://mdshare.live), github: [urbanmorph/mdshare](https://github.com/urbanmorph/mdshare), npm: [mdshare-mcp](https://www.npmjs.com/package/mdshare-mcp)) Free markdown sharing and collaboration. Upload a markdown, get shareable links with view/edit/comment permissions. WYSIWYG editor, inline comments, no login required. API + MCP server for AI integration.
 


### PR DESCRIPTION
Add Markstream to the 2026 upcoming Markdown libraries and tools list, following the repository contribution policy.

Markstream is an open-source streaming Markdown renderer for AI chat UIs. It supports incomplete Markdown while tokens arrive and is available for Vue, React, Svelte, and Angular, with Mermaid, KaTeX, long-response, and streaming-code-block support.