### PR TITLE
Add Glyph to Markdown to Website / Blog

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -44,6 +44,8 @@
 
 ### Markdown to Website / Blog
 
+**Glyph** (web: [`glyph-md.github.io`](https://glyph-md.github.io), github: [`hamidfzm/glyph` :octocat:](https://github.com/hamidfzm/glyph)) - native, cross-platform desktop app to view and edit folders of Markdown, with export to HTML, PDF, DOCX, and EPUB. GitHub Flavored Markdown, KaTeX math, Mermaid diagrams, wikilinks, and a graph view. Free & open source (MIT), built with Rust/Tauri.
+
 
 ### Markdown to Email
 


### PR DESCRIPTION
Adds **Glyph** to **Markdown to Website / Blog** in `UPCOMING.md` (per the 2026 upcoming-first policy noted in the README).

```
**Glyph** (web: [`glyph-md.github.io`](https://glyph-md.github.io), github: [`hamidfzm/glyph` :octocat:](https://github.com/hamidfzm/glyph)) - native, cross-platform desktop app to view and edit folders of Markdown, with export to HTML, PDF, DOCX, and EPUB. GitHub Flavored Markdown, KaTeX math, Mermaid diagrams, wikilinks, and a graph view. Free & open source (MIT), built with Rust/Tauri.
```

Glyph is MIT-licensed with source on GitHub, sitting alongside folder-of-Markdown tools like `md-fileserver` and `Compiiile`. (Glyph is also already listed in the sibling [awesome-markdown-editors](https://github.com/mundimark/awesome-markdown-editors) list.)
