### PR TITLE
Add emailmd to Markdown to Email

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -47,6 +47,8 @@
 
 ### Markdown to Email
 
+**emailmd**  (web: [emailmd.dev](https://www.emailmd.dev), github: [anypost/emailmd](https://github.com/anypost/emailmd), npm: [emailmd](https://www.npmjs.com/package/emailmd)) Markdown renderer for email: write markdown, get email-safe HTML that holds up in Outlook and Gmail, plus the plain text version. Handles the client quirks you would otherwise hand-code around, so templates stay the same syntax you already write in READMEs and chat. Directives cover what email needs and markdown lacks: buttons, callouts, columns, heroes, footers, social links. Ships a CLI, a React builder you can drop into your own app, ready-made templates, and a hosted MCP server for drafting, linting, and previewing emails from an AI assistant. MIT-licensed, sponsored by [Anypost](https://anypost.com/).
+
 
 ### Markdown to Presentation / Slideshow
 


### PR DESCRIPTION
Adding **emailmd** under `Markdown to Email` in UPCOMING.md.

- Web: https://www.emailmd.dev
- GitHub: https://github.com/anypost/emailmd
- npm: https://www.npmjs.com/package/emailmd

`emailmd` converts markdown into email-safe HTML that holds up
across clients, and returns the plain text version with it.

It also ships a CLI, a React builder, ready-made templates, and a hosted MCP
server for drafting emails from an AI assistant.

Source is on GitHub and MIT-licensed, so it belongs in the open-source list
rather than the Commercial Edition page. Disclosure: I maintain emailmd, and it
is sponsored by Anypost (noted in the project README).