### PR TITLE
Add Imprint: AI-native Markdown to PDF with automated 0-100 quality report

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ a free web alternative to PowerPoint and Keynote in Ruby
 - [markdown-pdf :octocat:](https://github.com/alanshaw/markdown-pdf), [(npm Package)](https://www.npmjs.com/package/markdown-pdf) -  converts Markdown files to PDFs
 - [em-dee-pdf :octocat:](https://github.com/brendandebeasi/em-dee-pdf) - converts Markdown files to styled PDFs using Typst with 18 built-in themes, LaTeX math, and syntax highlighting
 - [Resumx](https://resumx.dev) [:octocat:](https://github.com/resumx/resumx) - Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG
+- [Imprint :octocat:](https://github.com/263311487-ux/imprint-pdf), [(npm)](https://www.npmjs.com/package/imprint-pdf), [(PyPI)](https://pypi.org/project/imprint-pdf) - AI-native Markdown-to-PDF generator with 24 design-system themes, smart auto-skinning, math & Mermaid, and an automated 0-100 print-quality report
 
 
 ### Markdown Styles / Documents / Pages

--- a/README.md
+++ b/README.md
@@ -412,8 +412,8 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 - [markdown-pdf :octocat:](https://github.com/alanshaw/markdown-pdf), [(npm Package)](https://www.npmjs.com/package/markdown-pdf) -  converts Markdown files to PDFs
 - [em-dee-pdf :octocat:](https://github.com/brendandebeasi/em-dee-pdf) - converts Markdown files to styled PDFs using Typst with 18 built-in themes, LaTeX math, and syntax highlighting
+- [imprint-pdf :octocat:](https://github.com/263311487-ux/imprint-pdf), [(npm Package)](https://www.npmjs.com/package/imprint-pdf) - AI-native, print-grade PDF generator — Markdown in, publisher-quality PDF out, with a built-in 0–100 print-quality report
 - [Resumx](https://resumx.dev) [:octocat:](https://github.com/resumx/resumx) - Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG
-- [Imprint :octocat:](https://github.com/263311487-ux/imprint-pdf), [(npm)](https://www.npmjs.com/package/imprint-pdf), [(PyPI)](https://pypi.org/project/imprint-pdf) - AI-native Markdown-to-PDF generator with 24 design-system themes, smart auto-skinning, math & Mermaid, and an automated 0-100 print-quality report
 
 
 ### Markdown Styles / Documents / Pages

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ a free web alternative to PowerPoint and Keynote in Ruby
 
 - [markdown-pdf :octocat:](https://github.com/alanshaw/markdown-pdf), [(npm Package)](https://www.npmjs.com/package/markdown-pdf) -  converts Markdown files to PDFs
 - [em-dee-pdf :octocat:](https://github.com/brendandebeasi/em-dee-pdf) - converts Markdown files to styled PDFs using Typst with 18 built-in themes, LaTeX math, and syntax highlighting
-- [imprint-pdf :octocat:](https://github.com/263311487-ux/imprint-pdf), [(npm Package)](https://www.npmjs.com/package/imprint-pdf) - AI-native, print-grade PDF generator — Markdown in, publisher-quality PDF out, with a built-in 0–100 print-quality report
+- [Imprint :octocat:](https://github.com/263311487-ux/imprint-pdf), [(npm)](https://www.npmjs.com/package/imprint-pdf), [(PyPI)](https://pypi.org/project/imprint-pdf) - AI-native Markdown-to-PDF generator with 24 design-system themes, smart auto-skinning, math & Mermaid, and an automated 0-100 print-quality report
 - [Resumx](https://resumx.dev) [:octocat:](https://github.com/resumx/resumx) - Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG
 
 


### PR DESCRIPTION
Adds [Imprint](https://github.com/263311487-ux/imprint-pdf) to the "Markdown to Portable Document Format (PDF)" section.

Imprint converts Markdown to publisher-grade PDF (strong CJK typography, 24 design-system themes, smart auto-skinning, math + Mermaid, MCP server) and then scores its own output 0-100 on print-quality checks (fonts, widows/orphans, contrast, image DPI, PDF/UA) with evidence for every deduction.

Available via `npx imprint-pdf`, pip, and an MCP server for AI agents.